### PR TITLE
Drive image utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 drives/
 images/
+mnt/
 vm.user.conf

--- a/launcher.sh
+++ b/launcher.sh
@@ -9,6 +9,9 @@ if [ -f "$CUSTOM_CONFIG_PATH" ]; then
     . $CUSTOM_CONFIG_PATH
 fi
 
+# Load extra modules
+source ./modules/drive-utils.sh
+
 # Default args for qemu
 arguments_list=(
     "-enable-kvm"
@@ -35,6 +38,7 @@ else
 fi
 
 # Process params
+# TODO: Split implementation to module
 if ([ $# -eq 0 ] || [ "$1" = "run" ]); then
     # Launch the VM in default mode
     arguments_list+=(
@@ -77,6 +81,8 @@ elif [ "$1" = "init" ]; then
     echo "EXAMPLE:"
     echo "  ./launcher.sh install ~/Downloads/downloaded-android-image.iso"
     exit 0
+elif [ "$1" = "drive" ]; then
+    driveutils_cli_process_args "${@:2}"
 elif [ "$1" = "help" ]; then
     # Show help messages
     echo "Usage: ./launcher.sh [COMMAND]"
@@ -86,6 +92,7 @@ elif [ "$1" = "help" ]; then
     echo "  init            : Prepare everything for VM, initialize drives."
     echo "  install <IMAGE> : Run the Virtual Machine in installation mode with"
     echo "                    <IMAGE> path to the Android image to be installed"
+    # TODO: Add "drive" helper
     echo "  help            : Show this help message."
     echo
     echo "NOTES:"

--- a/launcher.sh
+++ b/launcher.sh
@@ -9,7 +9,8 @@ if [ -f "$CUSTOM_CONFIG_PATH" ]; then
     . $CUSTOM_CONFIG_PATH
 fi
 
-# Load extra modules
+# Load modules
+source ./modules/core.sh
 source ./modules/drive-utils.sh
 
 # Default args for qemu

--- a/launcher.sh
+++ b/launcher.sh
@@ -91,9 +91,9 @@ elif [ "$1" = "help" ]; then
     echo "  run             : (Default) Run the Virtual Machine in normal mode."
     echo "  init            : Prepare everything for VM, initialize drives."
     echo "  install <IMAGE> : Run the Virtual Machine in installation mode with"
-    echo "                    <IMAGE> path to the Android image to be installed"
-    echo "  drive <...>     : Set of utilities to manage the VM drive."
-    echo "                    the VM drive."
+    echo "                    <IMAGE> path to the Android image to be"
+    echo "                    installed."
+    echo "  drive <CMD>     : Set of utilities to manage the VM drive."
     echo "  help            : Show this help message."
     echo
     echo "NOTES:"

--- a/launcher.sh
+++ b/launcher.sh
@@ -92,7 +92,8 @@ elif [ "$1" = "help" ]; then
     echo "  init            : Prepare everything for VM, initialize drives."
     echo "  install <IMAGE> : Run the Virtual Machine in installation mode with"
     echo "                    <IMAGE> path to the Android image to be installed"
-    # TODO: Add "drive" helper
+    echo "  drive <...>     : Set of utilities to manage the VM drive."
+    echo "                    the VM drive."
     echo "  help            : Show this help message."
     echo
     echo "NOTES:"

--- a/modules/core.sh
+++ b/modules/core.sh
@@ -1,0 +1,9 @@
+# Core components for global use within the scope of this project.
+
+
+require_root () {
+    if [[ $(/usr/bin/id -u) -ne 0 ]]; then
+        echo "This action reqires the root privileges"
+        exit 1
+    fi
+}

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -7,6 +7,7 @@ driveutils_mount () {
     echo "[ Mounting the disk image ]"
     qemu-nbd --connect=/dev/nbd0 $DRIVE_PATH
     mkdir -v -p "$DRIVE_MOUNT_PATH"
+    sleep 5;
     mount /dev/nbd0p1 $DRIVE_MOUNT_PATH
 
     echo "[ Drive was successfully mounted to the '$(realpath $DRIVE_MOUNT_PATH)' directory ]"

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -7,7 +7,6 @@ driveutils_mount () {
     echo "Mounting the disk image"
     qemu-nbd --connect=/dev/nbd0 $DRIVE_PATH
     mkdir -v $DRIVE_MOUNT_PATH
-    diskimage_initialize
     mount /dev/nbd0p1 $DRIVE_MOUNT_PATH
 
     echo "Drive was successfully mounted to the '$(realpath $DRIVE_MOUNT_PATH)' directory"

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -1,3 +1,6 @@
+# Drive image (qcow2) managing utilities
+
+
 __driveutils_load_modules () {
     echo "[ Loading the kernel modules ]"
     modprobe -v nbd max_part=8
@@ -62,6 +65,8 @@ __driveutils_mountdir_delete () {
 # Load kernel modules and mount the drive to a local folder inside the root
 # of current project
 driveutils_mount () {
+    require_root
+
     __driveutils_load_modules
     __driveutils_nbd_connect
     __driveutils_mountdir_create
@@ -70,6 +75,8 @@ driveutils_mount () {
 
 # Unmount the drive and unload the kernel modules
 driveutils_umount () {
+    require_root
+
     __driveutils_nbd_umount
     __driveutils_nbd_disconnect
     __driveutils_unload_modules
@@ -89,6 +96,10 @@ driveutils_cli_process_args () {
         echo "  mount  : Mount the VM drive to the path provided with"
         echo "           'DRIVE_MOUNT_PATH' var in the configuration file."
         echo "  umount : Unmount the VM drive and unload all modules."
+        echo ""
+        echo "NOTES:"
+        echo "  The \"mount\" and \"umount\" commands require root privileges"
+        echo "  to execute."
     elif ([ "${arguments_arr[0]}" == "mount" ]); then
         driveutils_mount
     elif ([ "${arguments_arr[0]}" == "umount" ]); then

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -15,7 +15,7 @@ driveutils_mount () {
 # Unmount the drive and unload the kernel modules
 driveutils_umount () {
     echo "Unmounting the drive image"
-    umount $DRIVE_MOUNT_PATH
+    umount /dev/nbd0p1
     qemu-nbd --disconnect /dev/nbd0
 
     echo "Unloading the kernel modules and removing the temp mount dir"

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -44,7 +44,7 @@ __driveutils_mountdir_delete () {
 driveutils_mount () {
     mount_tries=1
     __driveutils_load_modules
-    #__driveutils_nbd_connect
+    __driveutils_nbd_connect
     __driveutils_mountdir_create
 
     until __driveutils_nbd_mount; do

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -1,27 +1,27 @@
 # Load kernel modules and mount the drive to a local folder inside the root
 # of current project
 driveutils_mount () {
-    echo "Loading the kernel modules"
+    echo "[ Loading the kernel modules ]"
     modprobe -v nbd max_part=8
 
-    echo "Mounting the disk image"
+    echo "[ Mounting the disk image ]"
     qemu-nbd --connect=/dev/nbd0 $DRIVE_PATH
     mkdir -v $DRIVE_MOUNT_PATH
     mount /dev/nbd0p1 $DRIVE_MOUNT_PATH
 
-    echo "Drive was successfully mounted to the '$(realpath $DRIVE_MOUNT_PATH)' directory"
+    echo "[ Drive was successfully mounted to the '$(realpath $DRIVE_MOUNT_PATH)' directory ]"
 }
 
 # Unmount the drive and unload the kernel modules
 driveutils_umount () {
-    echo "Unmounting the drive image"
+    echo "[ Unmounting the drive image ]"
     umount /dev/nbd0p1
     qemu-nbd --disconnect /dev/nbd0
 
-    echo "Unloading the kernel modules and removing the temp mount dir"
+    echo "[ Unloading the kernel modules and removing the temp mount dir ]"
     rmmod -v nbd
     rm -rfv $DRIVE_MOUNT_PATH
-    echo "Drive was successfully unmounted from the '$(realpath $DRIVE_MOUNT_PATH)' directory"
+    echo "[ Drive was successfully unmounted from the '$(realpath $DRIVE_MOUNT_PATH)' directory ]"
 }
 
 # Process the CLI args

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -7,8 +7,10 @@ driveutils_mount () {
     echo "[ Mounting the disk image ]"
     qemu-nbd --connect=/dev/nbd0 $DRIVE_PATH
     mkdir -v -p "$DRIVE_MOUNT_PATH"
-    sleep 5;
-    mount /dev/nbd0p1 $DRIVE_MOUNT_PATH
+    until mount /dev/nbd0p1 "$DRIVE_MOUNT_PATH"; do 
+        echo "Attempting to mount the drive"
+        sleep 2
+    done
 
     echo "[ Drive was successfully mounted to the '$(realpath $DRIVE_MOUNT_PATH)' directory ]"
 }
@@ -16,7 +18,7 @@ driveutils_mount () {
 # Unmount the drive and unload the kernel modules
 driveutils_umount () {
     echo "[ Unmounting the drive image ]"
-    umount /dev/nbd0p1
+    umount -v /dev/nbd0p1
     qemu-nbd --disconnect /dev/nbd0
 
     echo "[ Unloading the kernel modules and removing the temp mount dir ]"

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -28,10 +28,22 @@ driveutils_umount () {
 driveutils_cli_process_args () {
     arguments_arr=("${@}")
 
-    if ([ "${arguments_arr[0]}" == "mount" ]); then
+    if ([ $# -eq 0 ] || [ "${arguments_arr[0]}" = "help" ]); then
+        echo "Usage: ./launcher.sh drive [COMMAND]"
+        echo "About: Set of utilities to manage the VM drive."
+        echo
+        echo "COMMANDS:"
+        echo "  help   : (Default) Show this help message."
+        echo "  mount  : Mount the VM drive to the path provided with"
+        echo "           'DRIVE_MOUNT_PATH' var in the configuration file."
+        echo "  umount : Unmount the VM drive and unload all modules."
+    elif ([ "${arguments_arr[0]}" == "mount" ]); then
         driveutils_mount
     elif ([ "${arguments_arr[0]}" == "umount" ]); then
         driveutils_umount
+    else
+        echo "Error: Invalid argument: \"${arguments_arr[0]}\""
+        exit 1
     fi
 
     exit 0

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -6,7 +6,7 @@ driveutils_mount () {
 
     echo "[ Mounting the disk image ]"
     qemu-nbd --connect=/dev/nbd0 $DRIVE_PATH
-    mkdir -v $DRIVE_MOUNT_PATH
+    mkdir -v -p "$DRIVE_MOUNT_PATH"
     mount /dev/nbd0p1 $DRIVE_MOUNT_PATH
 
     echo "[ Drive was successfully mounted to the '$(realpath $DRIVE_MOUNT_PATH)' directory ]"
@@ -20,7 +20,7 @@ driveutils_umount () {
 
     echo "[ Unloading the kernel modules and removing the temp mount dir ]"
     rmmod -v nbd
-    rm -rfv $DRIVE_MOUNT_PATH
+    rm -rfv "$DRIVE_MOUNT_PATH"
     echo "[ Drive was successfully unmounted from the '$(realpath $DRIVE_MOUNT_PATH)' directory ]"
 }
 

--- a/modules/drive-utils.sh
+++ b/modules/drive-utils.sh
@@ -1,0 +1,39 @@
+# Load kernel modules and mount the drive to a local folder inside the root
+# of current project
+driveutils_mount () {
+    echo "Loading the kernel modules"
+    modprobe -v nbd max_part=8
+
+    echo "Mounting the disk image"
+    qemu-nbd --connect=/dev/nbd0 $DRIVE_PATH
+    mkdir -v $DRIVE_MOUNT_PATH
+    diskimage_initialize
+    mount /dev/nbd0p1 $DRIVE_MOUNT_PATH
+
+    echo "Drive was successfully mounted to the '$(realpath $DRIVE_MOUNT_PATH)' directory"
+}
+
+# Unmount the drive and unload the kernel modules
+driveutils_umount () {
+    echo "Unmounting the drive image"
+    umount $DRIVE_MOUNT_PATH
+    qemu-nbd --disconnect /dev/nbd0
+
+    echo "Unloading the kernel modules and removing the temp mount dir"
+    rmmod -v nbd
+    rm -rfv $DRIVE_MOUNT_PATH
+    echo "Drive was successfully unmounted from the '$(realpath $DRIVE_MOUNT_PATH)' directory"
+}
+
+# Process the CLI args
+driveutils_cli_process_args () {
+    arguments_arr=("${@}")
+
+    if ([ "${arguments_arr[0]}" == "mount" ]); then
+        driveutils_mount
+    elif ([ "${arguments_arr[0]}" == "umount" ]); then
+        driveutils_umount
+    fi
+
+    exit 0
+}

--- a/vm.conf
+++ b/vm.conf
@@ -23,3 +23,6 @@ ADB_PORT=4444
 # Path to the VM drive default location.
 # All dirs will be created automatically on "init" call.
 DRIVE_PATH="./drives/android-image.qcow2.img"
+
+# Path to the VM drive mount location when using the "drive" CLI commands.
+DRIVE_MOUNT_PATH="./mnt/"


### PR DESCRIPTION
# About
The very basic set of utilities for the virtual machine qcow2 images management, available from the main `launcher` sub-commands. Also provides the basic extendable modules structure for the new features to be easy implemented in future.

# Reason
See #4 

# Features
- Mount *(+ unmount)* the qcow2 drive image with one command.